### PR TITLE
Dropping pending updates

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -25,6 +25,7 @@ const run = async () => {
   } else {
     bot.start({
       allowed_updates: config.BOT_ALLOWED_UPDATES,
+      drop_pending_updates: true,
       onStart: ({ username }) =>
         logger.info({
           msg: "bot running...",


### PR DESCRIPTION
In development mode dropping pending updates helped me a lot because pending old callback queries crashed when bot starts.