### PR TITLE
refactor: :recycle: use `type-fest` & needless typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,8 @@
         "node-fetch": "3.2.6",
         "pino": "8.1.0",
         "pino-pretty": "8.1.0",
-        "prom-client": "14.0.1"
+        "prom-client": "14.0.1",
+        "type-fest": "2.16.0"
       },
       "devDependencies": {
         "@types/debug": "4.1.7",
@@ -2169,6 +2170,18 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globals/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4482,12 +4495,11 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.16.0.tgz",
+      "integrity": "sha512-qpaThT2HQkFb83gMOrdKVsfCN7LKxP26Yq+smPzY1FqoHRjqmjqHXA7n5Gkxi8efirtbeEUxzfEdePthQWCuHw==",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6274,6 +6286,14 @@
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
       }
     },
     "globalyzer": {
@@ -7917,10 +7937,9 @@
       }
     },
     "type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.16.0.tgz",
+      "integrity": "sha512-qpaThT2HQkFb83gMOrdKVsfCN7LKxP26Yq+smPzY1FqoHRjqmjqHXA7n5Gkxi8efirtbeEUxzfEdePthQWCuHw=="
     },
     "typescript": {
       "version": "4.7.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "node-fetch": "3.2.6",
     "pino": "8.1.0",
     "pino-pretty": "8.1.0",
-    "prom-client": "14.0.1"
+    "prom-client": "14.0.1",
+    "type-fest": "2.16.0"
   },
   "devDependencies": {
     "@types/debug": "4.1.7",

--- a/src/services/users.service.ts
+++ b/src/services/users.service.ts
@@ -1,10 +1,10 @@
 import _ from "lodash";
-import { Prisma, PrismaClient } from "@prisma/client";
-import { DeepPartial } from "@bot/types";
+import type { Prisma, PrismaClient } from "@prisma/client";
+import type { PartialDeep } from "type-fest";
 
 export const createService = (prisma: PrismaClient) =>
   Object.assign(prisma.user, {
-    findByTelegramId: <T extends DeepPartial<Prisma.UserFindUniqueArgs>>(
+    findByTelegramId: <T extends PartialDeep<Prisma.UserFindUniqueArgs>>(
       telegramId: number,
       args?: Prisma.SelectSubset<T, Prisma.UserFindUniqueArgs>
     ) => {
@@ -14,12 +14,10 @@ export const createService = (prisma: PrismaClient) =>
         },
       };
 
-      return prisma.user.findUnique(_.merge(query, args)) as unknown as Promise<
-        Prisma.UserGetPayload<typeof args>
-      >;
+      return prisma.user.findUnique(_.merge(query, args));
     },
 
-    upsertByTelegramId: <T extends DeepPartial<Prisma.UserUpsertArgs>>(
+    upsertByTelegramId: <T extends PartialDeep<Prisma.UserUpsertArgs>>(
       telegramId: number,
       args: Prisma.SelectSubset<T, Prisma.UserUpsertArgs>
     ) => {
@@ -33,12 +31,10 @@ export const createService = (prisma: PrismaClient) =>
         update: {},
       };
 
-      return prisma.user.upsert(_.merge(query, args)) as unknown as Promise<
-        Prisma.UserGetPayload<typeof args>
-      >;
+      return prisma.user.upsert(_.merge(query, args));
     },
 
-    updateByTelegramId: <T extends DeepPartial<Prisma.UserUpdateArgs>>(
+    updateByTelegramId: <T extends PartialDeep<Prisma.UserUpdateArgs>>(
       telegramId: number,
       args: Prisma.SelectSubset<T, Prisma.UserUpdateArgs>
     ) => {
@@ -49,8 +45,6 @@ export const createService = (prisma: PrismaClient) =>
         data: {},
       };
 
-      return prisma.user.update(_.merge(query, args)) as unknown as Promise<
-        Prisma.UserGetPayload<typeof args>
-      >;
+      return prisma.user.update(_.merge(query, args));
     },
   });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,2 @@
 export { Context, LocalContextFlavor } from "./context";
 export { SessionData } from "./session";
-
-export type DeepPartial<T> = {
-  [P in keyof T]?: DeepPartial<T[P]>;
-};


### PR DESCRIPTION
#### Refactoring
- [x] not need typings for [`prisma-client`](https://github.com/prisma/prisma/tree/main/packages/client) methods in `user.service`
- [x] use [`type-fest`](https://github.com/sindresorhus/type-fest) for `DeepPartial` type