### PR TITLE
Update session.middleware.ts

### DIFF
--- a/src/bot/middlewares/session.middleware.ts
+++ b/src/bot/middlewares/session.middleware.ts
@@ -9,10 +9,11 @@ export const session = (
     initial: () => ({}),
     storage,
     getSessionKey(ctx: ContextWithoutSession) {
+      const chatId = ctx.chat?.id ?? ctx.inlineQuery?.from?.id;
       // Give every user their one personal session storage per bot
       // (an independent session for the same user in each bot)
-      return ctx.chat === undefined || ctx.me === undefined
+      return chatId === undefined || ctx.me === undefined
         ? undefined
-        : `${ctx.chat.id}/${ctx.me.id}`;
+        : `${chatId}/${ctx.me.id}`;
     },
   });


### PR DESCRIPTION
the inline query doesn't have `chat` property 
this change will prevent the occurrence of 

```ERROR (28639): Cannot access session data because the custom `getSessionKey` function returned undefined for this update!
    update_id: 1019584430
    inline_query: {
      "id": "3002287605007794077",
      "from": {
        "id": 699024555,
        "is_bot": false,
        "first_name": "Malk.Adnan",
        "username": "albaazy",
        "language_code": "en"
      },
      "chat_type": "channel",
      "query": "بله تفاه",
      "offset": ""
    }```