### PR TITLE
fix(app): make changes for deploying to vercel and add command ping-p…

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,13 +1,12 @@
-import process from 'node:process'
-import { handle } from '@hono/node-server/vercel'
-import { createBot } from '#root/bot/index.js'
-import { createConfig } from '#root/config.js'
-import { createServer } from '#root/server/index.js'
-import { createLogger } from '#root/logger.js'
+import { createBot } from '#root/bot/index.js';
+import { convertKeysToCamelCase, createConfig } from "#root/config.js";
+import { logger } from '#root/logger.js';
+import { createServer } from '#root/server/index.js';
+import { handle } from '@hono/node-server/vercel';
+import process from 'node:process';
 
 // @ts-expect-error create config from environment variables
 const config = createConfig(convertKeysToCamelCase(process.env))
-const logger = createLogger(config)
 
 const bot = createBot(config.botToken, {
   config,

--- a/locales/en.ftl
+++ b/locales/en.ftl
@@ -3,6 +3,7 @@
 start-command-description = Start the bot
 language-command-description = Change language
 setcommands-command-description = Set bot commands
+ping-pong-command-description = Test bot work. Ping-Pong
 
 ## Welcome Feature
 

--- a/locales/uk.ftl
+++ b/locales/uk.ftl
@@ -1,0 +1,22 @@
+## Commands
+
+start-command-description = Запустити бота
+language-command-description = Змінити мову
+setcommands-command-description = Встановити команди бота
+ping-pong-command-description = Тест бота. Ping-Pong
+## Welcome Feature
+
+welcome = Ласкаво просимо!
+
+## Language Feature
+
+language-select = Будь ласка, оберіть мову
+language-changed = Мову успішно змінено!
+
+## Admin Feature
+
+admin-commands-updated = Команди оновлено.
+
+## Unhandled Feature
+
+unhandled = Невідома команда. Спробуйте /start

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@grammyjs/types": "3.11.1",
         "@hono/node-server": "1.12.0",
         "callback-data": "1.1.1",
+        "dotenv": "^16.4.7",
         "grammy": "1.27.0",
         "grammy-guard": "0.5.0",
         "hono": "4.5.2",
@@ -2367,6 +2368,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/duplexer": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@grammyjs/types": "3.11.1",
     "@hono/node-server": "1.12.0",
     "callback-data": "1.1.1",
+    "dotenv": "^16.4.7",
     "grammy": "1.27.0",
     "grammy-guard": "0.5.0",
     "hono": "4.5.2",

--- a/src/bot/features/ping.ts
+++ b/src/bot/features/ping.ts
@@ -1,0 +1,17 @@
+import type { Context } from '#root/bot/context.js'
+import { logHandle } from '#root/bot/helpers/logging.js'
+import { Composer } from 'grammy'
+
+const composer = new Composer<Context>()
+
+const feature = composer.chatType('private')
+
+feature.command('ping', logHandle('command-ping-pong'), (ctx) => {
+  return ctx.reply('pong')
+})
+
+feature.filter((ctx) => ctx.msg?.text?.toLocaleLowerCase() === 'ping').on('msg:text', logHandle('msg-ping-pong'), (ctx) => {
+  return ctx.reply('pong')
+})
+
+export { composer as PingFeature }

--- a/src/bot/features/welcome.ts
+++ b/src/bot/features/welcome.ts
@@ -1,13 +1,15 @@
-import { Composer } from 'grammy'
 import type { Context } from '#root/bot/context.js'
 import { logHandle } from '#root/bot/helpers/logging.js'
+import { Composer, Keyboard } from 'grammy'
 
 const composer = new Composer<Context>()
 
 const feature = composer.chatType('private')
 
-feature.command('start', logHandle('command-start'), (ctx) => {
-  return ctx.reply(ctx.t('welcome'))
+feature.command('start', logHandle('command-start'), async (ctx) => {
+  return ctx.reply(ctx.t('welcome'), {
+    reply_markup: new Keyboard().text('ping').resized(),
+  })
 })
 
 export { composer as welcomeFeature }

--- a/src/bot/handlers/commands/command-definitions.ts
+++ b/src/bot/handlers/commands/command-definitions.ts
@@ -1,0 +1,34 @@
+import { i18n } from "#root/bot/i18n.js";
+
+export interface Command {
+  command: string;
+  description: (lang: string) => string;
+  isAdmin?: true;
+  scope?: "private" | "group" | "all";
+}
+
+export const commands: Command[] = [
+  {
+    command: "start",
+    description: (lang) => i18n.t(lang, "start-command-description"),
+    scope: "private",
+  },
+  {
+    command: "ping",
+    description: (lang) => i18n.t(lang, "ping-pong-command-description"),
+    scope: "private",
+  },
+  {
+    command: "setcommands",
+    description: (lang) => i18n.t(lang, "setcommands-command-description"),
+    isAdmin: true,
+    scope: "private",
+  },
+];
+
+export const languageCommand = {
+  command: "language",
+  description: (localeCode: string) => 
+    i18n.t(localeCode, "language-command-description"),
+  scope: "private",
+} as const;

--- a/src/bot/handlers/commands/setcommands.ts
+++ b/src/bot/handlers/commands/setcommands.ts
@@ -1,108 +1,94 @@
-import type { BotCommand, LanguageCode } from '@grammyjs/types'
-import type { CommandContext } from 'grammy'
-import { i18n, isMultipleLocales } from '#root/bot/i18n.js'
-import type { Context } from '#root/bot/context.js'
+import type { Context } from "#root/bot/context.js";
+import { i18n, isMultipleLocales } from "#root/bot/i18n.js";
+import type { BotCommand, LanguageCode } from "@grammyjs/types";
+import type { CommandContext } from "grammy";
+import { commands, languageCommand, type Command } from "./command-definitions.js";
 
-function getLanguageCommand(localeCode: string): BotCommand {
-  return {
-    command: 'language',
-    description: i18n.t(localeCode, 'language-command-description'),
-  }
-}
+type CommandScope = {
+  type: "all_private_chats" | "all_group_chats";
+} | {
+  type: "chat";
+  chat_id: number;
+};
 
-function getPrivateChatCommands(localeCode: string): BotCommand[] {
-  return [
-    {
-      command: 'start',
-      description: i18n.t(localeCode, 'start-command-description'),
-    },
-  ]
-}
+type SetCommandsOptions = {
+  language_code?: LanguageCode;
+  scope: CommandScope;
+};
 
-function getPrivateChatAdminCommands(localeCode: string): BotCommand[] {
-  return [
-    {
-      command: 'setcommands',
-      description: i18n.t(localeCode, 'setcommands-command-description'),
-    },
-  ]
-}
+const filterCommands = (commands: Command[], { isAdminOnly = false, scope }: { isAdminOnly?: boolean; scope?: Command["scope"] }) =>
+  commands.filter(cmd => {
+    if (scope && cmd.scope !== scope) return false;
+    return isAdminOnly ? cmd.isAdmin : !cmd.isAdmin;
+  });
 
-function getGroupChatCommands(_localeCode: string): BotCommand[] {
-  return []
-}
+const formatBotCommand = (command: Command, localeCode: string): BotCommand => ({
+  command: command.command,
+  description: command.description(localeCode),
+});
+
+const formatLanguageCommand = (localeCode: string): BotCommand => ({
+  command: languageCommand.command,
+  description: languageCommand.description(localeCode),
+});
+
+const setCommandsForScope = async (
+  ctx: CommandContext<Context>,
+  localeCode: string,
+  filteredCommands: Command[],
+  options: SetCommandsOptions,
+) => {
+  const botCommands = [
+    ...filteredCommands.map(cmd => formatBotCommand(cmd, localeCode)),
+    ...(isMultipleLocales ? [formatLanguageCommand(localeCode)] : []),
+  ];
+  
+  await ctx.api.setMyCommands(botCommands, options);
+};
+
+const setCommandsForAllLocales = async (
+  ctx: CommandContext<Context>,
+  filteredCommands: Command[],
+  options: Omit<SetCommandsOptions, "language_code">,
+) => {
+  if (!isMultipleLocales) return;
+
+  const requests = i18n.locales.map(code =>
+    setCommandsForScope(ctx, code, filteredCommands, {
+      ...options,
+      language_code: code as LanguageCode,
+    }),
+  );
+
+  await Promise.all(requests);
+};
 
 export async function setCommandsHandler(ctx: CommandContext<Context>) {
-  const DEFAULT_LANGUAGE_CODE = 'en'
+  const defaultLocale = (await ctx.i18n.getLocale()) || "en";
+  
+  // Set commands for private chats
+  const privateCommands = filterCommands(commands, { scope: "private" });
+  await setCommandsForScope(ctx, defaultLocale, privateCommands, {
+    scope: { type: "all_private_chats" },
+  });
+  await setCommandsForAllLocales(ctx, privateCommands, {
+    scope: { type: "all_private_chats" },
+  });
 
-  // set private chat commands
-  await ctx.api.setMyCommands(
-    [
-      ...getPrivateChatCommands(DEFAULT_LANGUAGE_CODE),
-      ...(isMultipleLocales ? [getLanguageCommand(DEFAULT_LANGUAGE_CODE)] : []),
-    ],
-    {
-      scope: {
-        type: 'all_private_chats',
-      },
-    },
-  )
+  // Set commands for group chats
+  const groupCommands = filterCommands(commands, { scope: "group" });
+  await setCommandsForScope(ctx, defaultLocale, groupCommands, {
+    scope: { type: "all_group_chats" },
+  });
+  await setCommandsForAllLocales(ctx, groupCommands, {
+    scope: { type: "all_group_chats" },
+  });
 
-  if (isMultipleLocales) {
-    const requests = i18n.locales.map(code =>
-      ctx.api.setMyCommands(
-        [
-          ...getPrivateChatCommands(code),
-          ...(isMultipleLocales
-            ? [getLanguageCommand(DEFAULT_LANGUAGE_CODE)]
-            : []),
-        ],
-        {
-          language_code: code as LanguageCode,
-          scope: {
-            type: 'all_private_chats',
-          },
-        },
-      ),
-    )
+  // Set admin commands
+  const adminCommands = [...privateCommands, ...filterCommands(commands, { isAdminOnly: true, scope: "private" })];
+  await setCommandsForScope(ctx, defaultLocale, adminCommands, {
+    scope: { type: "chat", chat_id: Number(ctx.config.botAdmins) },
+  });
 
-    await Promise.all(requests)
-  }
-
-  // set group chat commands
-  await ctx.api.setMyCommands(getGroupChatCommands(DEFAULT_LANGUAGE_CODE), {
-    scope: {
-      type: 'all_group_chats',
-    },
-  })
-
-  if (isMultipleLocales) {
-    const requests = i18n.locales.map(code =>
-      ctx.api.setMyCommands(getGroupChatCommands(code), {
-        language_code: code as LanguageCode,
-        scope: {
-          type: 'all_group_chats',
-        },
-      }),
-    )
-
-    await Promise.all(requests)
-  }
-
-  // set private chat commands for owner
-  await ctx.api.setMyCommands(
-    [
-      ...getPrivateChatCommands(DEFAULT_LANGUAGE_CODE),
-      ...getPrivateChatAdminCommands(DEFAULT_LANGUAGE_CODE),
-      ...(isMultipleLocales ? [getLanguageCommand(DEFAULT_LANGUAGE_CODE)] : []),
-    ],
-    {
-      scope: {
-        type: 'chat',
-        chat_id: Number(ctx.config.botAdmins),
-      },
-    },
-  )
-
-  return ctx.reply(ctx.t('admin-commands-updated'))
+  return ctx.reply(ctx.t("admin-commands-updated"));
 }

--- a/src/bot/index.ts
+++ b/src/bot/index.ts
@@ -1,21 +1,22 @@
+import type { Context, SessionData } from '#root/bot/context.js'
+import { createContextConstructor } from '#root/bot/context.js'
+import { adminFeature } from '#root/bot/features/admin.js'
+import { languageFeature } from '#root/bot/features/language.js'
+import { PingFeature } from '#root/bot/features/ping.js'
+import { unhandledFeature } from '#root/bot/features/unhandled.js'
+import { welcomeFeature } from '#root/bot/features/welcome.js'
+import { errorHandler } from '#root/bot/handlers/error.js'
+import { i18n, isMultipleLocales } from '#root/bot/i18n.js'
+import { session } from '#root/bot/middlewares/session.js'
+import { updateLogger } from '#root/bot/middlewares/update-logger.js'
+import type { Config } from '#root/config.js'
+import type { Logger } from '#root/logger.js'
 import { autoChatAction } from '@grammyjs/auto-chat-action'
 import { hydrate } from '@grammyjs/hydrate'
 import { hydrateReply, parseMode } from '@grammyjs/parse-mode'
+import { sequentialize } from '@grammyjs/runner'
 import type { BotConfig, StorageAdapter } from 'grammy'
 import { Bot as TelegramBot } from 'grammy'
-import { sequentialize } from '@grammyjs/runner'
-import { welcomeFeature } from '#root/bot/features/welcome.js'
-import { adminFeature } from '#root/bot/features/admin.js'
-import { languageFeature } from '#root/bot/features/language.js'
-import { unhandledFeature } from '#root/bot/features/unhandled.js'
-import { errorHandler } from '#root/bot/handlers/error.js'
-import { updateLogger } from '#root/bot/middlewares/update-logger.js'
-import { session } from '#root/bot/middlewares/session.js'
-import type { Context, SessionData } from '#root/bot/context.js'
-import { createContextConstructor } from '#root/bot/context.js'
-import { i18n, isMultipleLocales } from '#root/bot/i18n.js'
-import type { Logger } from '#root/logger.js'
-import type { Config } from '#root/config.js'
 
 interface Dependencies {
   config: Config
@@ -61,6 +62,7 @@ export function createBot(token: string, dependencies: Dependencies, options: Op
 
   // Handlers
   protectedBot.use(welcomeFeature)
+  protectedBot.use(PingFeature)
   protectedBot.use(adminFeature)
   if (isMultipleLocales)
     protectedBot.use(languageFeature)


### PR DESCRIPTION
# Changes
- Added dotenv for Vercel deployment configuration
- Added ping-pong command functionality:
  - `/ping` command  and text msg `ping` now respond with "pong"
- Added Ukrainian (uk) localization with translations for all commands and messages
- Createed [src/bot/handlers/commands/command-definitions.ts] to simplify adding new commands.
- Updated [src/bot/handlers/commands/setcommands.ts]

Link to the working bot
[@grammy_vercel_bot](https://t.me/grammy_vercel_bot)

![how it work](https://github.com/user-attachments/assets/e7c13186-3432-4ed1-b60c-a2b070364622)

